### PR TITLE
disabled autocomplete on most pages (except printer selection)

### DIFF
--- a/src/main/resources/templates/reg/atcon-order-attendee-specialty.html
+++ b/src/main/resources/templates/reg/atcon-order-attendee-specialty.html
@@ -10,7 +10,7 @@
 <body>
 
 <div layout:fragment="content">
-            <form action="#" th:object="${attendee}" th:if="${attendee!=null}" method="post">
+            <form action="#" th:object="${attendee}" th:if="${attendee!=null}" method="post" autocomplete="off">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <ul th:if="${#fields.hasErrors('*')}">
                     <li th:each="err : ${#fields.errors('*')}" th:text="${err}">Input is incorrect</li>

--- a/src/main/resources/templates/reg/atcon-order-attendee.html
+++ b/src/main/resources/templates/reg/atcon-order-attendee.html
@@ -11,7 +11,7 @@
 
 <div layout:fragment="content">
 
-            <form action="#" th:object="${attendee}" th:if="${attendee!=null}" method="post">
+            <form action="#" th:object="${attendee}" th:if="${attendee!=null}" method="post" autocomplete="off">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <ul th:if="${#fields.hasErrors('*')}">
                     <li th:each="err : ${#fields.errors('*')}" th:text="${err}">Input is incorrect</li>

--- a/src/main/resources/templates/reg/search.html
+++ b/src/main/resources/templates/reg/search.html
@@ -10,7 +10,7 @@
 
     <div class="row" th:if="${#authorization.expression('hasAuthority(''attendee_search'')')}">
         <div class="col-sm-12 mb-2">
-            <form class="form-inline justify-content-center" action="/search" method="get">
+            <form class="form-inline justify-content-center" action="/search" method="get" autocomplete="off">
                 <input class="form-control mr-2" th:value="${query}" type="text" name="q" placeholder="Attendee Name" autofocus>
                 <input class="btn btn-primary" type="submit" value="Search">
             </form>

--- a/src/main/resources/templates/utility/tillsession.html
+++ b/src/main/resources/templates/utility/tillsession.html
@@ -8,7 +8,7 @@
 <div layout:fragment="content" class="container">
 
     <div class="form-group row">
-        <form class="form-inline col-sm-7" method="POST">
+        <form class="form-inline col-sm-7" method="POST" autocomplete="off">
             <label class="col-form-label col-sm-3" for="tillName">Till Number</label>
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
             <input class="form-control mr-2" type="text" name="tillName" id="tillName" th:value="${tillName}"/>


### PR DESCRIPTION
Added an HTML attribute to prevent firefox from showing a dropdown of previously typed items