### PR TITLE
Switch to Jetty from Tomcat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Version 1.0.2 (pending)
 - Added each user's total logged in time for the displayed day to the Login History report
 - Time period is displayed when you hover over a cell in the Login History Report
 - Added autocomplete dropdown to staff search
+- Switch to Jetty from Tomcat, which increased performance, especially for file uploads
 
 Version 1.0.1 (11/14/2019)
 - Staff check in: don't search staff list until 2 characters have been entered in search (for performance)

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,17 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-tomcat</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jetty</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/src/main/java/org/kumoricon/registration/utility/PrinterController.java
+++ b/src/main/java/org/kumoricon/registration/utility/PrinterController.java
@@ -1,10 +1,8 @@
 package org.kumoricon.registration.utility;
 
 
-import org.apache.tomcat.util.codec.binary.Base64;
 import org.kumoricon.registration.controlleradvice.CookieControllerAdvice;
 import org.kumoricon.registration.controlleradvice.PrinterSettings;
-import org.kumoricon.registration.model.badge.BadgeService;
 import org.kumoricon.registration.print.BadgePrintService;
 import org.kumoricon.registration.print.PrinterInfoService;
 import org.slf4j.Logger;
@@ -23,13 +21,15 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.Base64;
 
 @Controller
 public class PrinterController {
     private final PrinterInfoService printerInfoService;
     private final BadgePrintService badgePrintService;
     private static final Logger log = LoggerFactory.getLogger(PrinterController.class);
+    private final Base64.Decoder decoder = Base64.getUrlDecoder();
+    private final Base64.Encoder encoder = Base64.getUrlEncoder();
 
     public PrinterController(PrinterInfoService printerInfoService, BadgePrintService badgePrintService) {
         this.printerInfoService = printerInfoService;
@@ -46,9 +46,9 @@ public class PrinterController {
 
         if (previousUrl == null || previousUrl.isBlank()) {
             previousLink = request.getHeader("referer");
-            previousUrl = Base64.encodeBase64URLSafeString(previousLink.getBytes());
+            previousUrl = encoder.encodeToString(previousLink.getBytes());
         } else {
-            previousLink = new String(Base64.decodeBase64(previousUrl));
+            previousLink = new String(decoder.decode(previousUrl));
         }
         model.addAttribute("printer", settings.getPrinterName());
         model.addAttribute("xOffset", settings.getxOffset());
@@ -70,7 +70,7 @@ public class PrinterController {
         String newPrinter = printer.trim();
         String urlSafePrinterName = getUrlSafePrinterName(newPrinter);
         previousUrl = sanitizePreviousUrl(previousUrl);
-        String previousLink = new String(Base64.decodeBase64(previousUrl));
+        String previousLink = new String(decoder.decode(previousUrl));
         PrinterSettings settings = new PrinterSettings(newPrinter, xOffset, yOffset);
 
         model.addAttribute("previousUrl", previousUrl);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,7 @@ spring.session.jdbc.initialize-schema=always
 spring.session.timeout=1800
 server.servlet.session.timeout=1800
 
+server.jetty.max-http-post-size=20MB
 spring.servlet.multipart.max-file-size=20MB
 spring.servlet.multipart.max-request-size=20MB
 spring.servlet.multipart.enabled=true
@@ -42,8 +43,7 @@ server.port = 8080
 
 # Required to work properly with (AWS) load balancers, otherwise redirects would be sent to http://... instead of
 # https://...
-server.tomcat.protocol-header=x-forwarded-proto
-server.tomcat.remote-ip-header=x-forwarded-for
+server.use-forward-headers=true
 
 # Logging
 logging.pattern.console=${CONSOLE_LOG_PATTERN:%clr(%d{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %X{user} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}}


### PR DESCRIPTION
Changing the application server to Jetty from Tomcat
improved performance drastically when uploading images.
With a test script that uploaded a 592 KB file 500 times,
Tomcat would average ~250ms with the maximum latency of
17,000ms+ (!)

With the same file, Jetty averaged ~185ms, with a maximum
of 221 ms.

There's quite possibly a configuration option that could be
set in Tomcat to improve performance, but I'm fine with
switching to Jetty because I use it more often at work.

Fixes #39 