### PR TITLE
Remove emergency contact info from prereg check in screen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Version 1.1.0 (pending)
 - Upload staff photos as JPG instead of PNG
 - Save staff photos and signatures with the name {name}-{id}-photo/signature-{timestamp}.jpg/png
 - Added configurable run-time settings (schema change) and configuration screen
+- Remove emergency contact info from pre-reg check in screen
 
 Version 1.0.1 (11/14/2019)
 - Staff check in: don't search staff list until 2 characters have been entered in search (for performance)

--- a/src/main/resources/templates/reg/checkin-id.html
+++ b/src/main/resources/templates/reg/checkin-id.html
@@ -34,14 +34,6 @@
                     <td th:text="|${#temporals.format(attendee.birthDate , 'MM/dd/yyyy')} (${attendee.getAge()})|">01/01/1980 (39)</td>
                 </tr>
                 <tr>
-                    <td>Emergency Contact</td>
-                    <td th:text="|${attendee.emergencyContactFullName} - ${attendee.emergencyContactPhone}|">Jane Doe - 123-555-1212</td>
-                </tr>
-                <tr th:if="${attendee.isMinor()}">
-                    <td>Parent Contact</td>
-                    <td th:text="|${attendee.parentFullName} - ${attendee.parentPhone}|">Jane Doe - 123-555-1212</td>
-                </tr>
-                <tr>
                     <td>Notes</td>
                     <td>
                         <p th:each="note : ${history}">


### PR DESCRIPTION
Removing this so that staff aren't tempted to spend time
verifying emergency contact information. (Which was a
problem because it slowed down the lines)

While valuable, we're relying on attendees to enter the
correct information when they preregister.

Fixes #16 