### PR TITLE
Fix NullPointerException from trying to check length of Cash auth number

### DIFF
--- a/src/main/java/org/kumoricon/registration/reg/PaymentController.java
+++ b/src/main/java/org/kumoricon/registration/reg/PaymentController.java
@@ -101,11 +101,14 @@ public class PaymentController {
         }
 
         paymentData.setAmount(payment.getAmount());
-        if(payment.getAuthNumber().length() <= 10)
+        if( !payment.getPaymentType().equals("cash") )
         {
-            paymentData.setAuthNumber(payment.getAuthNumber());
-        } else {
-            throw new RuntimeException("Invalid auth number: " + payment.getAuthNumber() + " (must be 10 characters or less)");
+            if(payment.getAuthNumber().length() <= 10)
+            {
+                paymentData.setAuthNumber(payment.getAuthNumber());
+            } else {
+                throw new RuntimeException("Invalid auth number: " + payment.getAuthNumber() + " (must be 10 characters or less)");
+            }
         }
 
         try {
@@ -181,12 +184,18 @@ public class PaymentController {
         paymentData.setTillSessionId(currentTillSession.getId());
         paymentData.setAmount(payment.getAmount());
 
-        if(payment.getAuthNumber().length() <= 10)
+        paymentData.setAmount(payment.getAmount());
+
+        if( !payment.getPaymentType().equals("cash") )
         {
-            paymentData.setAuthNumber(payment.getAuthNumber());
-        } else {
-            throw new RuntimeException("Invalid auth number: " + payment.getAuthNumber() + " (must be 10 characters or less)");
+            if(payment.getAuthNumber().length() <= 10)
+            {
+                paymentData.setAuthNumber(payment.getAuthNumber());
+            } else {
+                throw new RuntimeException("Invalid auth number: " + payment.getAuthNumber() + " (must be 10 characters or less)");
+            }
         }
+
 
         switch (payment.getPaymentType()) {
             case "cash":


### PR DESCRIPTION
realized while trying to split up the payment pages that a ```NullPointerException``` was being created from trying to check auth number for all payment types (null pointer for Cash payments). 

Did not add a ```paymentData.setAuthNumber(payment.getAuthNumber());``` for Cash payments (was default to set for all) as it's still just setting it to null. If there's a purpose for having it I can re-add it back in.