### PR TITLE
Added order hand off screen/buttons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Version 1.1.0 (pending)
 - Allow fewer digits in check number field (at-con payment)
 - Added payment timestamp to till detail report
 - Reworked rights on Current User Info screen
+- Added Order Hand Off screen and buttons for at-con orders. (schema change)
+
 
 Version 1.0.1 (11/14/2019)
 - Staff check in: don't search staff list until 2 characters have been entered in search (for performance)

--- a/src/main/java/org/kumoricon/registration/model/order/OrderHandOffDTO.java
+++ b/src/main/java/org/kumoricon/registration/model/order/OrderHandOffDTO.java
@@ -1,0 +1,37 @@
+package org.kumoricon.registration.model.order;
+
+import java.time.OffsetDateTime;
+
+public class OrderHandOffDTO {
+    private final int orderId;
+    private final int fromUserId;
+    private final String fromUserName;
+    private final OffsetDateTime timestamp;
+    private final String stage;
+
+    public OrderHandOffDTO(int orderId, int fromUserId, String fromUserName, OffsetDateTime timestamp, String stage) {
+        this.orderId = orderId;
+        this.fromUserId = fromUserId;
+        this.fromUserName = fromUserName;
+        this.timestamp = timestamp;
+        this.stage = stage;
+    }
+
+    public int getOrderId() {
+        return orderId;
+    }
+
+    public int getFromUserId() {
+        return fromUserId;
+    }
+
+    public String getFromUserName() {
+        return fromUserName;
+    }
+
+    public OffsetDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public String getStage() { return stage; }
+}

--- a/src/main/java/org/kumoricon/registration/model/order/OrderHandOffRepository.java
+++ b/src/main/java/org/kumoricon/registration/model/order/OrderHandOffRepository.java
@@ -1,0 +1,71 @@
+package org.kumoricon.registration.model.order;
+
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class OrderHandOffRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public OrderHandOffRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderHandOffDTO> findAll() {
+        try {
+            return jdbcTemplate.query("select orderhandoffs.*, u.username from orderhandoffs join users u on orderhandoffs.user_id = u.id",
+                    new OrderHandOffRowMapper());
+        } catch (EmptyResultDataAccessException e) {
+            return new ArrayList<>();
+        }
+    }
+
+    @Transactional
+    public void deleteHandOff(Integer orderId) {
+        assert orderId != null;
+        final String SQL = "delete from orderhandoffs where order_id = :orderId";
+        jdbcTemplate.update(SQL, Map.of("orderId", orderId));
+    }
+
+    @Transactional
+    public void saveHandOff(OrderHandOffDTO orderHandOffDTO) {
+        assert orderHandOffDTO != null;
+        SqlParameterSource params = new BeanPropertySqlParameterSource(orderHandOffDTO);
+        final String SQL = "INSERT INTO orderhandoffs (order_id, user_id, timestamp, stage) VALUES " +
+                "(:orderId, :fromUserId, :timestamp, :stage) ON CONFLICT (order_id) " +
+                " DO UPDATE SET user_id=:fromUserId, timestamp=:timestamp, stage=:stage";
+        jdbcTemplate.update(SQL, params);
+    }
+
+    public OrderHandOffDTO findByOrderId(Integer orderId) {
+        return jdbcTemplate.queryForObject("select orderhandoffs.*, u.username from orderhandoffs join users u on orderhandoffs.user_id = u.id WHERE order_id = :orderId",
+                Map.of("orderId", orderId), new OrderHandOffRowMapper());
+    }
+
+
+    private static class OrderHandOffRowMapper implements RowMapper<OrderHandOffDTO>
+    {
+        @Override
+        public OrderHandOffDTO mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new OrderHandOffDTO(
+                    rs.getInt("order_id"),
+                    rs.getInt("user_id"),
+                    rs.getString("username"),
+                    rs.getObject("timestamp", OffsetDateTime.class),
+                    rs.getString("stage"));
+        }
+    }
+}

--- a/src/main/java/org/kumoricon/registration/reg/OrderHandOffController.java
+++ b/src/main/java/org/kumoricon/registration/reg/OrderHandOffController.java
@@ -1,0 +1,78 @@
+package org.kumoricon.registration.reg;
+
+import org.kumoricon.registration.model.order.OrderHandOffDTO;
+import org.kumoricon.registration.model.order.OrderHandOffRepository;
+import org.kumoricon.registration.model.user.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.time.OffsetDateTime;
+
+@Controller
+public class OrderHandOffController {
+    private static final Logger log = LoggerFactory.getLogger(OrderHandOffController.class);
+    private final OrderHandOffRepository orderHandOffRepository;
+    private static final String STAGE_ORDER = "order";
+    private static final String STAGE_PRINT_BADGE = "printbadge";
+
+    public OrderHandOffController(OrderHandOffRepository orderHandOffRepository) {
+        this.orderHandOffRepository = orderHandOffRepository;
+    }
+
+    @RequestMapping(value = "/reg/atconorder/{orderId}/handoff",method = RequestMethod.POST)
+    @PreAuthorize("hasAuthority('at_con_registration')")
+    public String atConOrderHandOff(@AuthenticationPrincipal User user,
+                                    @PathVariable Integer orderId) {
+        log.info("flagged order {} for handoff", orderId);
+
+        OrderHandOffDTO o = new OrderHandOffDTO(orderId, user.getId(), user.getUsername(), OffsetDateTime.now(), STAGE_ORDER);
+        orderHandOffRepository.saveHandOff(o);
+        return "redirect:/?msg=Flagged+order+for+hand+off";
+    }
+
+    @RequestMapping(value = "/reg/atconorder/{orderId}/printbadges/handoff" ,method = RequestMethod.POST)
+    @PreAuthorize("hasAuthority('at_con_registration')")
+    public String atConOrderHandOffBadge(@AuthenticationPrincipal User user,
+                                         @PathVariable Integer orderId) {
+        log.info("flagged order {} for handoff at badge print", orderId);
+
+        OrderHandOffDTO o = new OrderHandOffDTO(orderId, user.getId(), user.getUsername(), OffsetDateTime.now(), STAGE_PRINT_BADGE);
+        orderHandOffRepository.saveHandOff(o);
+        return "redirect:/?msg=Flagged+order+for+hand+off";
+    }
+
+
+    @RequestMapping(value = "/reg/atconorder/{orderId}/takeover",method = RequestMethod.POST)
+    @PreAuthorize("hasAuthority('at_con_registration')")
+    public String atConOrderTakeOver(Model model, @PathVariable Integer orderId) {
+        log.info("took over order id {}", orderId);
+        OrderHandOffDTO handOff = orderHandOffRepository.findByOrderId(orderId);
+        String redirect;
+        if (STAGE_ORDER.equals(handOff.getStage())) {
+            redirect = "redirect:/reg/atconorder/" + orderId;
+        } else if (STAGE_PRINT_BADGE.equals(handOff.getStage())) {
+            redirect = "redirect:/reg/atconorder/" + orderId + "/printbadges";
+        } else {
+            log.error("Unknown order stage {}", handOff.getStage());
+            throw new RuntimeException("Unknown order stage");
+        }
+        orderHandOffRepository.deleteHandOff(orderId);
+        return redirect;
+    }
+
+    @RequestMapping(value = "/reg/atconorder/takeover")
+    @PreAuthorize("hasAuthority('at_con_registration')")
+    public String atConOrderHandOffList(Model model) {
+        model.addAttribute("handoffs", orderHandOffRepository.findAll());
+        return "reg/atcon-order-handoff";
+    }
+
+}
+

--- a/src/main/resources/database/schema.sql
+++ b/src/main/resources/database/schema.sql
@@ -188,6 +188,23 @@ create index if not exists payments_order_id_index
     on payments (order_id);
 
 
+create table if not exists orderhandoffs
+(
+    order_id integer not null
+        constraint orderhandoffs_order_id_orders_fk
+            references orders,
+    user_id integer not null
+        constraint orderhandoffs_user_id_users_fk
+            references users,
+    timestamp timestamp with time zone not null,
+    stage text not null
+);
+
+
+create unique index if not exists orderhandoffs_order_id_uindex
+    on orderhandoffs (order_id);
+
+
 
 create table if not exists attendees
 (

--- a/src/main/resources/templates/layout/fragments.html
+++ b/src/main/resources/templates/layout/fragments.html
@@ -21,6 +21,7 @@
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                             <input class="dropdown-item" type="submit" value="New At Con Order">
                         </form>
+                        <a class="dropdown-item" th:if="${#authorization.expression('hasAuthority(''at_con_registration'')')}" href="/reg/atconorder/takeover">Take Over At Con Order</a>
                         <a class="dropdown-item" th:if="${#authorization.expression('hasAuthority(''attendee_search'')')}" href="/search">Attendee Search</a>
                         <a class="dropdown-item" th:if="${#authorization.expression('hasAuthority(''attendee_search'')')}" href="/searchbybadge">Search by Badge Type</a>
                         <a class="dropdown-item" th:if="${#authorization.expression('hasAuthority(''print_guest_badge'')')}" href="/guests">Guest Badges</a>

--- a/src/main/resources/templates/reg/atcon-order-attendee-specialty.html
+++ b/src/main/resources/templates/reg/atcon-order-attendee-specialty.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
+<html layout:decorate="~{layout/basenomenu}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org">
 <head>
     <title>Edit Attendee</title>

--- a/src/main/resources/templates/reg/atcon-order-attendee.html
+++ b/src/main/resources/templates/reg/atcon-order-attendee.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
+<html layout:decorate="~{layout/basenomenu}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org">
 <head>
     <title>Edit Attendee</title>

--- a/src/main/resources/templates/reg/atcon-order-card-payment.html
+++ b/src/main/resources/templates/reg/atcon-order-card-payment.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
+<html layout:decorate="~{layout/basenomenu}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org">
 <head>
     <title>Payment</title>

--- a/src/main/resources/templates/reg/atcon-order-cash-payment.html
+++ b/src/main/resources/templates/reg/atcon-order-cash-payment.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
+<html layout:decorate="~{layout/basenomenu}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org">
 <head>
     <title>Payment</title>

--- a/src/main/resources/templates/reg/atcon-order-check-payment.html
+++ b/src/main/resources/templates/reg/atcon-order-check-payment.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
+<html layout:decorate="~{layout/basenomenu}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org">
 <head>
     <title>Payment</title>

--- a/src/main/resources/templates/reg/atcon-order-handoff.html
+++ b/src/main/resources/templates/reg/atcon-order-handoff.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org">
+<head>
+    <title>Take Over Order</title>
+</head>
+<body>
+
+<div layout:fragment="content" class="container">
+
+    <div class="row">
+        <div class="col-12">
+
+            <table class="table table-bordered table-striped table-sm">
+                <thead>
+                <tr>
+                    <td>Order ID</td>
+                    <td>From User</td>
+                    <td>Timestamp</td>
+                    <td></td>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:if="${handoffs.size() == 0}">
+                    <td colspan="4">No orders flagged for hand off</td>
+                </tr>
+                <tr th:each="oh : ${handoffs}">
+                    <td th:text="${oh.orderId}"></td>
+                    <td th:text="${oh.fromUserName}"></td>
+                    <td th:text="${dts.format(oh.timestamp)}"></td>
+                    <td>
+                        <form th:action="@{/reg/atconorder/{orderId}/takeover(orderId=${oh.orderId})}" method="post">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                            <input type="submit" value="Take Over" class="btn btn-sm btn-primary">
+                        </form>
+                    </td>
+                </tr>
+
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/reg/atcon-order-payment-id.html
+++ b/src/main/resources/templates/reg/atcon-order-payment-id.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org">
+<html layout:decorate="~{layout/basenomenu}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org">
 <head>
     <title>Payment</title>
     <script type="text/javascript" src="/js/payment.js" defer></script>

--- a/src/main/resources/templates/reg/atcon-order-payment.html
+++ b/src/main/resources/templates/reg/atcon-order-payment.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
+<html layout:decorate="~{layout/basenomenu}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org">
 <head>
     <title>Payment</title>

--- a/src/main/resources/templates/reg/atcon-order-printbadges.html
+++ b/src/main/resources/templates/reg/atcon-order-printbadges.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
+<html layout:decorate="~{layout/basenomenu}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org">
 <head>
     <title>Print Badges</title>
@@ -37,6 +37,10 @@
         <form th:action="@{/reg/atconorder/{orderId}/printbadges(orderId=${orderId})}" method="post">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
             <input type="submit" value="Printed Successfully" class="btn btn-primary mb-2">
+        </form>
+        <form th:action="@{/reg/atconorder/{orderId}/printbadges/handoff(orderId=${orderId})}" method="post">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+            <input type="submit" value="Hand Off Order" class="btn mb-2 btn-secondary ml-2">
         </form>
     </div>
 

--- a/src/main/resources/templates/reg/atcon-order.html
+++ b/src/main/resources/templates/reg/atcon-order.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html layout:decorate="~{layout/base}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
+<html layout:decorate="~{layout/basenomenu}" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org">
 <head>
     <title>Order</title>
@@ -72,10 +72,16 @@
                 Take Payment</a>
             <form th:action="@{/reg/atconorder/{orderId}/complete(orderId=${order.id})}" method="post">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-                <input type="submit" value="Order Complete" class="btn mb2"
-                   th:classappend="${!canComplete} ? 'btn-secondary' : 'btn-primary'"
-                   th:disabled="${!canComplete}">
+                <input type="submit" value="Order Complete" class="btn mb-2"
+                    th:classappend="${!canComplete} ? 'btn-secondary' : 'btn-primary'"
+                    th:disabled="${!canComplete}">
             </form>
+            <form th:action="@{/reg/atconorder/{orderId}/handoff(orderId=${order.id})}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <input type="submit" value="Hand Off Order" class="btn mb-2 btn-secondary"
+                       th:disabled="${order.paid}">
+            </form>
+
         </div>
     </div>
 </div>


### PR DESCRIPTION
Order Hand Off allows a user to flag an at-con order for hand off, and another user to
easily find that order and resume from the same screen. The point of this is to easily move
customers to another station if there is some problem (for example, a printer dies).

Currently you can hand off from the main order screen and the print badges screen.