### PR TITLE
Till Detail report gets cut off when printing from Firefox #40

### DIFF
--- a/src/main/resources/templates/reports/tillsessions-id.html
+++ b/src/main/resources/templates/reports/tillsessions-id.html
@@ -51,7 +51,7 @@
     </div>
 
     <div class="row" th:if="${showIndividualOrders}">
-        <div class="col-8">
+        <div class="col-12">
             <table class="table table-sm table-bordered">
                 <tr>
                     <th>Order Id</th>

--- a/src/main/resources/templates/reports/tillsessions-id.html
+++ b/src/main/resources/templates/reports/tillsessions-id.html
@@ -60,8 +60,8 @@
                 </tr>
                 <tr th:each="o : ${tillSession.orderDTOs}">
                     <td th:text="${o.orderId}">123</td>
-                    <td class="text-nowrap" th:text="${o.badges}">3 adult weekend, 2 child weekend</td>
-                    <td class="text-nowrap" th:text="${o.payments}">$30 cash, $20 check<br></td>
+                    <td th:text="${o.badges}">3 adult weekend, 2 child weekend</td>
+                    <td th:text="${o.payments}">$30 cash, $20 check<br></td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
Removed the "text-nowrap" classes causing the data cutoff. This prevented the cutoff but brought back a problem where every line wrapped, taking up two lines. Changed the table's column size from 8 to 12 (the maximum for bootstrap). Smaller lines no longer wrap, but longer ones do.