### PR TITLE
Update Log4J version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,22 @@
 			<artifactId>http2-server</artifactId>
 			<version>9.4.43.v20210629</version>
 		</dependency>
+		<!--
+		Log4J version set explicitly because of
+		https://nvd.nist.gov/vuln/detail/CVE-2021-44228
+		It should be safe to go back to whatever version Spring Boot picks as soon as they
+		update to 2.15.0 or better.
+		 -->
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.15.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-to-slf4j</artifactId>
+			<version>2.15.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>


### PR DESCRIPTION
Because of https://nvd.nist.gov/vuln/detail/CVE-2021-44228